### PR TITLE
remove properties from chainspec

### DIFF
--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -2,7 +2,6 @@ pub(crate) mod dev;
 pub(crate) mod local_testnet;
 pub(crate) mod testnet_testnet;
 
-use serde_json::Map;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 use sp_core::{crypto::Ss58Codec, Pair, Public};
 use sp_finality_grandpa::AuthorityId as GrandpaId;

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -2,7 +2,6 @@ pub(crate) mod dev;
 pub(crate) mod local_testnet;
 pub(crate) mod testnet_testnet;
 
-use sc_service::Properties;
 use serde_json::Map;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 use sp_core::{crypto::Ss58Codec, Pair, Public};
@@ -77,13 +76,6 @@ fn get_from_seed<T: Public>(seed: &str) -> <T::Pair as Pair>::Public {
     T::Pair::from_string(&format!("//{}", seed), None)
         .expect("static values are valid; qed")
         .public()
-}
-
-fn properties() -> Properties {
-    let mut properties = Map::new();
-    properties.insert("tokenSymbol".into(), "USDv".into());
-    properties.insert("tokenDecimals".into(), 15.into());
-    properties
 }
 
 fn public_key_from_ss58<T: Public>(ss58: &str) -> Result<T, String> {

--- a/node/src/chain_spec/dev.rs
+++ b/node/src/chain_spec/dev.rs
@@ -1,5 +1,5 @@
 use crate::chain_spec::{
-    authority_keys_from_seed, get_account_id_from_seed, properties, ChainSpec, GenesisConfigBuilder,
+    authority_keys_from_seed, get_account_id_from_seed, ChainSpec, GenesisConfigBuilder,
 };
 use sc_service::ChainType;
 use sp_core::sr25519;
@@ -23,7 +23,7 @@ pub fn chain_spec() -> Result<ChainSpec, String> {
         vec![],
         None,
         None,
-        Some(properties()),
+        None,
         None,
     ))
 }

--- a/node/src/chain_spec/local_testnet.rs
+++ b/node/src/chain_spec/local_testnet.rs
@@ -1,5 +1,5 @@
 use crate::chain_spec::{
-    authority_keys_from_seed, get_account_id_from_seed, properties, ChainSpec, GenesisConfigBuilder,
+    authority_keys_from_seed, get_account_id_from_seed, ChainSpec, GenesisConfigBuilder,
 };
 use sc_service::ChainType;
 use sp_core::sr25519;
@@ -26,7 +26,7 @@ pub fn chain_spec() -> Result<ChainSpec, String> {
         vec![],
         None,
         None,
-        Some(properties()),
+        None,
         None,
     ))
 }

--- a/node/src/chain_spec/testnet_testnet.rs
+++ b/node/src/chain_spec/testnet_testnet.rs
@@ -1,5 +1,5 @@
 use crate::chain_spec::{
-    account_id_from_ss58, properties, public_key_from_ss58, ChainSpec, GenesisConfigBuilder,
+    account_id_from_ss58, public_key_from_ss58, ChainSpec, GenesisConfigBuilder,
 };
 use sc_service::ChainType;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
@@ -51,7 +51,7 @@ pub fn chain_spec() -> Result<ChainSpec, String> {
         vec![],
         None,
         Some("testnet"),
-        Some(properties()),
+        None,
         None,
     ))
 }


### PR DESCRIPTION
fix: since balances pallet has been removed(#26), setting properties in chainSpec does not serve a purpose anymore