### PR TITLE
feat:integrate orml-oracle pallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3637,6 +3637,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
+name = "orml-oracle"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7510e1d419f1ed7a62d43a82808deed6927ee8bd116227c77782cceed28df68d"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "funty",
+ "orml-traits",
+ "orml-utilities",
+ "parity-scale-codec",
+ "serde",
+ "sp-application-crypto",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "orml-tokens"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7887,6 +7906,7 @@ dependencies = [
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "hex-literal",
+ "orml-oracle",
  "orml-tokens",
  "orml-traits",
  "pallet-aura",

--- a/primitives/src/macros.rs
+++ b/primitives/src/macros.rs
@@ -60,4 +60,3 @@ macro_rules! enum_with_aux_fns {
         }
     }
 }
-

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -23,6 +23,7 @@ frame-system-rpc-runtime-api = { default-features = false, version = "3.0.0" }
 hex-literal = { default-features = false, optional = true, version = "0.3.1" }
 orml-tokens = { default-features = false, version = "0.4.0" }
 orml-traits = { default-features = false, version = "0.4.0" }
+orml-oracle = { default-features = false, version = "0.4.0" }
 pallet-aura = { default-features = false, version = "3.0.0" }
 pallet-grandpa = { default-features = false, version = "3.0.0" }
 pallet-membership = { default-features = false, version = "3.0.0" }
@@ -70,6 +71,7 @@ std = [
     'frame-system-rpc-runtime-api/std',
     'frame-system/std',
     'orml-tokens/std',
+    'orml-oracle/std',
     'pallet-aura/std',
     'pallet-grandpa/std',
     'pallet-membership/std',

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -253,6 +253,23 @@ impl vln_transfers::Config for Runtime {
     type Assets = Tokens;
 }
 
+parameter_types! {
+    pub const MinimumCount: u32 = 3;
+    pub const ExpiresIn: u32 = 600;
+    pub RootOperatorAccountId: AccountId = Sudo::key();
+}
+
+impl orml_oracle::Config for Runtime {
+    type Event = Event;
+    type OnNewData = ();
+    type CombineData = orml_oracle::DefaultCombineData<Runtime, MinimumCount, ExpiresIn>;
+    type Time = Timestamp;
+    type OracleKey = Asset;
+    type OracleValue = u64;
+    type RootOperatorAccountId = RootOperatorAccountId;
+    type WeightInfo = ();
+}
+
 construct_runtime! {
    pub enum Runtime
    where
@@ -272,6 +289,7 @@ construct_runtime! {
         Usdv: vln_backed_asset::<Instance1>::{Call, Event<T>, Module, Storage},
         Swaps: vln_human_swap::{Call, Event<T>, Module, Storage},
         Transfers: vln_transfers::{Call, Event<T>, Module, Storage},
+        Oracle: orml_oracle::{Call, Event<T>, Module, Storage},
     }
 }
 

--- a/types.json
+++ b/types.json
@@ -1,24 +1,30 @@
 {
-    "Address": "MultiAddress",
-    "LookupSource": "MultiAddress",
-    "Asset": {
-      "_enum": {
-        "Collateral": "Collateral",
-        "Usdv": null
-      }
-    },
-    "Collateral": {
-      "_enum": [
-        "Usdc"
-      ]
-    },
-    "CurrencyId": "Asset",
-    "CurrencyIdOf": "Asset",
-    "Share": "u32",
-    "Destination": {
-      "_enum": {
-        "Bank" : "Hash",
-        "Vln" : "AccountId"
-      }
+  "Address": "MultiAddress",
+  "LookupSource": "MultiAddress",
+  "BlockNumber": "u32",
+  "Index": "u32",
+  "Balance": "u64",
+  "Asset": {
+    "_enum": {
+      "Collateral": "Collateral",
+      "Fiat":"Fiat",
+      "Usdv": null
     }
-  }
+  },
+  "Collateral": {
+    "_enum": [
+      "Usdc"
+    ]
+  },
+  "Fiat": {
+    "_enum": [
+      "Cop",
+      "Vez"
+    ]
+  },
+  "CurrencyId": "Asset",
+  "CurrencyIdOf": "Asset",
+  "Share": "u32",
+  "OracleKey": "Asset",
+  "OracleValue": "u32"
+}


### PR DESCRIPTION
## Summary
Integrates the [orml-oracle](https://github.com/open-web3-stack/open-runtime-module-library/tree/master/oracle) pallet to allow price feeds on-chain. Currently the price feed can be simulated using [oracle-bot](https://github.com/stanly-johnson/orml-oracle-bot) but the plan is to use values from other onchain providers as they are ready.

Price of any asset can be fetch from other pallets using:

```rust
...
let vez_price = Oracle::get(&Asset::Fiat(Vez)), None);
...
```

#### Assumptions
- The baseCurrency is always `USD`, ie fetching the price of `VEZ` means the pair price of `VEZ/USD`
- Currently only the `sudo` account is permitted to add rates, will need to migrate this to a whitelist