### PR TITLE
Escrow pallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10938,6 +10938,7 @@ version = "0.1.0"
 dependencies = [
  "frame-support",
  "frame-system",
+ "orml-tokens",
  "orml-traits",
  "parity-scale-codec",
  "serde",
@@ -11152,6 +11153,7 @@ dependencies = [
  "sp-version",
  "substrate-wasm-builder 4.0.0",
  "vln-backed-asset",
+ "vln-escrow",
  "vln-foreign-asset",
  "vln-human-swap",
  "vln-primitives",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10945,7 +10945,6 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 3.0.0 (git+https://github.com/paritytech/substrate?branch=rococo-v1)",
  "vln-primitives",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10933,6 +10933,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "vln-escrow"
+version = "0.1.0"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "orml-traits",
+ "parity-scale-codec",
+ "serde",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std 3.0.0 (git+https://github.com/paritytech/substrate?branch=rococo-v1)",
+ "vln-primitives",
+]
+
+[[package]]
 name = "vln-foreign-asset"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     'pallets/human_swap',
     'pallets/transfers',
     'pallets/rate_provider',
+    'pallets/escrow',
     'primitives',
     'runtime'
 ]

--- a/pallets/escrow/Cargo.toml
+++ b/pallets/escrow/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+authors = ["Stanly Johnson <stanlyjohnson@outlook.com>"]
+edition = '2018'
+name = "vln-escrow"
+version = "0.1.0"
+license = "Unlicense"
+homepage = "https://github.com/valibre-org/vln-node/"
+repository = "https://github.com/valibre-org/vln-node/"
+description = "Allows users to post escrow on-chain"
+readme = "README.md"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1", default-features = false, version = '3.0.0' }
+frame-system = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1", default-features = false, version = '3.0.0' }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1", default-features = false, version = '3.0.0' }
+sp-std = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1", default-features = false }
+orml-traits = { git = "https://github.com/valibre-org/open-runtime-module-library", default-features = false }
+vln-primitives = { version = "0.1.0", path = "../../primitives" }
+
+[dev-dependencies]
+serde = { version = "1.0.101" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1", default-features = false, version = '3.0.0' }
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1", default-features = false, version = '3.0.0' }
+
+[features]
+default = ['std']
+std = [
+	'codec/std',
+	'frame-support/std',
+	'frame-system/std',
+	'sp-runtime/std',
+	'orml-traits/std',
+	'sp-std/std'
+]

--- a/pallets/escrow/Cargo.toml
+++ b/pallets/escrow/Cargo.toml
@@ -17,15 +17,14 @@ codec = { package = "parity-scale-codec", version = "2.0.0", default-features = 
 frame-support = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1", default-features = false, version = '3.0.0' }
 frame-system = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1", default-features = false, version = '3.0.0' }
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1", default-features = false, version = '3.0.0' }
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1", default-features = false }
 orml-traits = { git = "https://github.com/valibre-org/open-runtime-module-library", default-features = false }
-orml-tokens = { git = "https://github.com/valibre-org/open-runtime-module-library", default-features = false }
 vln-primitives = { version = "0.1.0", path = "../../primitives" }
 
 [dev-dependencies]
 serde = { version = "1.0.101" }
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1", default-features = false, version = '3.0.0' }
 sp-io = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1", default-features = false, version = '3.0.0' }
+orml-tokens = { git = "https://github.com/valibre-org/open-runtime-module-library", default-features = false }
 
 [features]
 default = ['std']
@@ -35,6 +34,4 @@ std = [
 	'frame-system/std',
 	'sp-runtime/std',
 	'orml-traits/std',
-	'sp-std/std',
-	'orml-tokens/std'
 ]

--- a/pallets/escrow/Cargo.toml
+++ b/pallets/escrow/Cargo.toml
@@ -19,6 +19,7 @@ frame-system = { git = "https://github.com/paritytech/substrate", branch = "roco
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1", default-features = false, version = '3.0.0' }
 sp-std = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1", default-features = false }
 orml-traits = { git = "https://github.com/valibre-org/open-runtime-module-library", default-features = false }
+orml-tokens = { git = "https://github.com/valibre-org/open-runtime-module-library", default-features = false }
 vln-primitives = { version = "0.1.0", path = "../../primitives" }
 
 [dev-dependencies]
@@ -34,5 +35,6 @@ std = [
 	'frame-system/std',
 	'sp-runtime/std',
 	'orml-traits/std',
-	'sp-std/std'
+	'sp-std/std',
+	'orml-tokens/std'
 ]

--- a/pallets/escrow/README.md
+++ b/pallets/escrow/README.md
@@ -1,0 +1,3 @@
+# Escrow Pallet
+
+This pallet will allow users to create an escrow onchain for any peer-to-peer transaction.

--- a/pallets/escrow/README.md
+++ b/pallets/escrow/README.md
@@ -1,6 +1,6 @@
 # Escrow Pallet
 
-This pallet will allow users to create an escrow onchain for a selected recipent. The pallet can be used to compliment the human swap pallet, to prove the existence of an escrow before the actual swap needs to be processed.
+This pallet will allow users to create an escrow onchain for a selected recipent. The pallet can be used to compliment the human swap pallet, to prove the existence of an escrow before the actual swap needs to be processed. The escrow pallet does not store the history of all the escrow transactions created by the user, it only cares about the current active escrow of the user/recipent.
 
 ## Terminology
 

--- a/pallets/escrow/README.md
+++ b/pallets/escrow/README.md
@@ -1,3 +1,31 @@
 # Escrow Pallet
 
-This pallet will allow users to create an escrow onchain for any peer-to-peer transaction.
+This pallet will allow users to create an escrow onchain for a selected recipent. The pallet can be used to compliment the human swap pallet, to prove the existence of an escrow before the actual swap needs to be processed.
+
+## Terminology
+
+- Created: An escrow has been created and amount reserved on chain.
+- Released: The escrow amount has been released to the selected recipent
+
+## Interface
+
+#### Events
+
+`EscrowCreated(T::AccountId, T::Asset, T::Amount)`,
+`EscrowReleased(T::AccountId, EscrowId)`,
+
+#### Extrinsics
+
+`create_escrow(origin, recipent, currency_id, amount)` - Create an escrow for the given currencyid/amount
+`release_escrow(origin, escrow_id)` - Release the escrow amount to recipent
+
+## Implementations
+
+The RatesProvider module provides implementations for the following traits.
+- [`EscrowHandler`](../../primitives/src/escrow.rs)
+
+## GenesisConfig
+
+The rates_provider pallet does not depend on the `GenesisConfig`
+
+License: Apache-2.0

--- a/pallets/escrow/src/lib.rs
+++ b/pallets/escrow/src/lib.rs
@@ -21,7 +21,7 @@ pub mod pallet {
 
     type BalanceOf<T> =
         <<T as Config>::Asset as MultiCurrency<<T as frame_system::Config>::AccountId>>::Balance;
-    type CurrencyIdOf<T> =
+    type AssetIdOf<T> =
         <<T as Config>::Asset as MultiCurrency<<T as frame_system::Config>::AccountId>>::CurrencyId;
 
     #[pallet::config]
@@ -47,7 +47,7 @@ pub mod pallet {
         T::AccountId,
         Twox64Concat,
         EscrowId,
-        EscrowDetail<T::AccountId, CurrencyIdOf<T>, BalanceOf<T>>,
+        EscrowDetail<T::AccountId, AssetIdOf<T>, BalanceOf<T>>,
     >;
 
     /// Current escrow index for a user
@@ -61,7 +61,7 @@ pub mod pallet {
     #[pallet::generate_deposit(pub(super) fn deposit_event)]
     pub enum Event<T: Config> {
         /// Rate has been updated
-        EscrowCreated(T::AccountId, CurrencyIdOf<T>, BalanceOf<T>),
+        EscrowCreated(T::AccountId, AssetIdOf<T>, BalanceOf<T>),
         /// Rates have been removed by LP
         EscrowReleased(T::AccountId, EscrowId),
     }
@@ -86,11 +86,11 @@ pub mod pallet {
         pub fn create_escrow(
             origin: OriginFor<T>,
             recipent: T::AccountId,
-            asset: CurrencyIdOf<T>,
+            asset: AssetIdOf<T>,
             amount: BalanceOf<T>,
         ) -> DispatchResultWithPostInfo {
             let who = ensure_signed(origin)?;
-            <Self as EscrowHandler<T::AccountId, CurrencyIdOf<T>, BalanceOf<T>>>::create_escrow(
+            <Self as EscrowHandler<T::AccountId, AssetIdOf<T>, BalanceOf<T>>>::create_escrow(
                 who, recipent, asset, amount,
             )?;
             Ok(().into())
@@ -104,18 +104,18 @@ pub mod pallet {
             escrow_id: EscrowId,
         ) -> DispatchResultWithPostInfo {
             let who = ensure_signed(origin)?;
-            <Self as EscrowHandler<T::AccountId, CurrencyIdOf<T>, BalanceOf<T>>>::release_escrow(
+            <Self as EscrowHandler<T::AccountId, AssetIdOf<T>, BalanceOf<T>>>::release_escrow(
                 who, escrow_id,
             )?;
             Ok(().into())
         }
     }
 
-    impl<T: Config> EscrowHandler<T::AccountId, CurrencyIdOf<T>, BalanceOf<T>> for Pallet<T> {
+    impl<T: Config> EscrowHandler<T::AccountId, AssetIdOf<T>, BalanceOf<T>> for Pallet<T> {
         fn create_escrow(
             from: T::AccountId,
             recipent: T::AccountId,
-            asset: CurrencyIdOf<T>,
+            asset: AssetIdOf<T>,
             amount: BalanceOf<T>,
         ) -> Result<EscrowId, DispatchError> {
             // try to reserve the amount in the user balance
@@ -164,7 +164,7 @@ pub mod pallet {
         fn get_escrow_details(
             from: T::AccountId,
             escrow_id: EscrowId,
-        ) -> Option<EscrowDetail<T::AccountId, CurrencyIdOf<T>, BalanceOf<T>>> {
+        ) -> Option<EscrowDetail<T::AccountId, AssetIdOf<T>, BalanceOf<T>>> {
             Escrow::<T>::get(from, escrow_id)
         }
     }

--- a/pallets/escrow/src/lib.rs
+++ b/pallets/escrow/src/lib.rs
@@ -45,9 +45,9 @@ pub mod pallet {
     /// that for any (sender,recipent) combo, only a single escrow is active. The history of escrow is not stored.
     pub(super) type Escrow<T: Config> = StorageDoubleMap<
         _,
-        Twox64Concat,
+        Blake2_128Concat,
         T::AccountId, // escrow creator
-        Twox64Concat,
+        Blake2_128Concat,
         T::AccountId, // escrow recipent
         EscrowDetail<AssetIdOf<T>, BalanceOf<T>>,
     >;

--- a/pallets/escrow/src/lib.rs
+++ b/pallets/escrow/src/lib.rs
@@ -1,0 +1,134 @@
+#![allow(
+    clippy::unused_unit,
+    unused_qualifications,
+    missing_debug_implementations
+)]
+#![cfg_attr(not(feature = "std"), no_std)]
+pub use pallet::*;
+
+// #[cfg(test)]
+// mod mock;
+
+// #[cfg(test)]
+// mod tests;
+
+#[frame_support::pallet]
+pub mod pallet {
+    use frame_support::{dispatch::DispatchResultWithPostInfo, pallet_prelude::*};
+    use frame_system::pallet_prelude::*;
+    use orml_traits::{MultiCurrency, MultiReservableCurrency};
+    use sp_runtime::traits::Zero;
+    use sp_runtime::FixedPointNumber;
+    use vln_primitives::{EscrowDetail, EscrowId, EscrowState};
+
+    type BalanceOf<T> =
+        <<T as Config>::Asset as MultiCurrency<<T as frame_system::Config>::AccountId>>::Balance;
+    type CurrencyIdOf<T> =
+        <<T as Config>::Asset as MultiCurrency<<T as frame_system::Config>::AccountId>>::CurrencyId;
+
+    #[pallet::config]
+    pub trait Config: frame_system::Config {
+        /// Because this pallet emits events, it depends on the runtime's definition of an event.
+        type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
+        /// the type of assets this pallet can hold in escrow
+        type Asset: MultiReservableCurrency<Self::AccountId>;
+    }
+
+    #[pallet::pallet]
+    #[pallet::generate_store(pub(super) trait Store)]
+    pub struct Pallet<T>(_);
+
+    #[pallet::storage]
+    #[pallet::getter(fn rates)]
+    /// Escrows created by a user, this method of storageDoubleMap is chosen since there is no usecase for
+    /// listing escrows by provider/currency. The escrow will only be referenced by the creator in
+    /// any transaction of interest.
+    pub(super) type Escrow<T: Config> = StorageDoubleMap<
+        _,
+        Twox64Concat,
+        T::AccountId,
+        Twox64Concat,
+        EscrowId,
+        EscrowDetail<T::AccountId, CurrencyIdOf<T>, BalanceOf<T>>,
+    >;
+
+    /// Current escrow index for a user
+    #[pallet::storage]
+    #[pallet::getter(fn swap_index)]
+    pub(super) type EscrowIndex<T: Config> =
+        StorageMap<_, Twox64Concat, T::AccountId, EscrowId, ValueQuery>;
+
+    #[pallet::event]
+    #[pallet::metadata(T::AccountId = "AccountId")]
+    #[pallet::generate_deposit(pub(super) fn deposit_event)]
+    pub enum Event<T: Config> {
+        /// Rate has been updated
+        EscrowCreated(T::AccountId, CurrencyIdOf<T>, BalanceOf<T>),
+        /// Rates have been removed by LP
+        EscrowReleased(T::AccountId, EscrowId),
+    }
+
+    #[pallet::error]
+    pub enum Error<T> {
+        /// The selected escrow does not exist
+        InvalidEscrow,
+    }
+
+    #[pallet::hooks]
+    impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+
+    #[pallet::call]
+    impl<T: Config> Pallet<T> {
+        /// This allows any user to create a new escrow, that releases only to specified recipent
+        /// The only action is to store the details of this escrow in storage and reserve
+        /// the specified amount.
+        #[pallet::weight(10_000 + T::DbWeight::get().writes(1))]
+        pub fn create_escrow(
+            origin: OriginFor<T>,
+            recipent: T::AccountId,
+            asset: CurrencyIdOf<T>,
+            amount: BalanceOf<T>,
+        ) -> DispatchResultWithPostInfo {
+            let who = ensure_signed(origin)?;
+            // try to reserve the amount in the user balance
+            T::Asset::reserve(asset, &who, amount)?;
+            let escrow_index = EscrowIndex::<T>::get(who.clone()) + 1;
+            // add the escrow detail to storage
+            Escrow::<T>::insert(who.clone(), escrow_index.clone(), EscrowDetail {
+                recipent,
+                asset,
+                amount,
+                state : EscrowState::Created
+            });
+            // update the escrow index
+            EscrowIndex::<T>::insert(who.clone(), escrow_index);
+            Self::deposit_event(Event::EscrowCreated(who, asset, amount));
+            Ok(().into())
+        }
+
+        /// Release any created escrow, this will transfer the reserved amount from the 
+        /// creator of the escrow to the assigned recipent
+        #[pallet::weight(10_000 + T::DbWeight::get().writes(1))]
+        pub fn release_escrow(
+            origin: OriginFor<T>,
+            escrow_id: EscrowId,
+        ) -> DispatchResultWithPostInfo {
+            let who = ensure_signed(origin)?;
+            // add the escrow detail to storage
+            Escrow::<T>::try_mutate(who.clone(), escrow_id.clone(), |maybe_escrow| -> DispatchResult {
+                let escrow = maybe_escrow.take().ok_or(Error::<T>::InvalidEscrow)?;
+                // unreserve the amount from the owner account
+                T::Asset::unreserve(escrow.asset, &who, escrow.amount);
+                // try to transfer the amount to recipent
+                T::Asset::transfer(escrow.asset, &who, &escrow.recipent, escrow.amount)?;
+                *maybe_escrow = Some(EscrowDetail {
+                    state : EscrowState::Released,
+                    ..escrow
+                });
+                Ok(())
+            })?;
+            Self::deposit_event(Event::EscrowReleased(who, escrow_id));
+            Ok(().into())
+        }
+    }
+}

--- a/pallets/escrow/src/mock.rs
+++ b/pallets/escrow/src/mock.rs
@@ -1,0 +1,95 @@
+use crate as escrow;
+use frame_support::{parameter_types, traits::GenesisBuild};
+use frame_system as system;
+use orml_traits::parameter_type_with_key;
+use sp_core::H256;
+use sp_runtime::{
+    testing::Header,
+    traits::{BlakeTwo256, IdentityLookup},
+};
+
+type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type Block = frame_system::mocking::MockBlock<Test>;
+pub type AccountId = u8;
+pub const ESCROW_CREATOR: AccountId = 10;
+pub const ESCROW_RECIPENT: AccountId = 11;
+pub const CURRENCY_ID: u32 = 2;
+
+frame_support::construct_runtime!(
+    pub enum Test where
+        Block = Block,
+        NodeBlock = Block,
+        UncheckedExtrinsic = UncheckedExtrinsic,
+    {
+        System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
+        Tokens: orml_tokens::{Pallet, Call, Config<T>, Storage, Event<T>},
+        Escrow: escrow::{Pallet, Call, Storage, Event<T>},
+    }
+);
+
+parameter_types! {
+    pub const BlockHashCount: u64 = 250;
+    pub const SS58Prefix: u8 = 42;
+}
+
+impl system::Config for Test {
+    type BaseCallFilter = ();
+    type BlockWeights = ();
+    type BlockLength = ();
+    type DbWeight = ();
+    type Origin = Origin;
+    type Call = Call;
+    type Index = u64;
+    type BlockNumber = u64;
+    type Hash = H256;
+    type Hashing = BlakeTwo256;
+    type AccountId = AccountId;
+    type Lookup = IdentityLookup<Self::AccountId>;
+    type Header = Header;
+    type Event = Event;
+    type BlockHashCount = BlockHashCount;
+    type Version = ();
+    type PalletInfo = PalletInfo;
+    type AccountData = ();
+    type OnNewAccount = ();
+    type OnKilledAccount = ();
+    type SystemWeightInfo = ();
+    type SS58Prefix = SS58Prefix;
+    type OnSetCode = ();
+}
+
+parameter_type_with_key! {
+    pub ExistentialDeposits: |currency_id: u32| -> u32 {
+        0u32
+    };
+}
+
+impl orml_tokens::Config for Test {
+    type Amount = i64;
+    type Balance = u32;
+    type CurrencyId = u32;
+    type Event = Event;
+    type ExistentialDeposits = ExistentialDeposits;
+    type OnDust = ();
+    type WeightInfo = ();
+}
+
+impl escrow::Config for Test {
+    type Event = Event;
+    type Asset = Tokens;
+}
+
+// Build genesis storage according to the mock runtime.
+pub fn new_test_ext() -> sp_io::TestExternalities {
+    let mut t = system::GenesisConfig::default()
+        .build_storage::<Test>()
+        .unwrap();
+
+    orml_tokens::GenesisConfig::<Test> {
+        endowed_accounts: vec![(ESCROW_CREATOR, CURRENCY_ID, 100)],
+    }
+    .assimilate_storage(&mut t)
+    .unwrap();
+
+    t.into()
+}

--- a/pallets/escrow/src/tests.rs
+++ b/pallets/escrow/src/tests.rs
@@ -1,0 +1,109 @@
+use crate::mock::*;
+use crate::Escrow as EscrowStore;
+use frame_support::{assert_noop, assert_ok};
+use orml_traits::MultiCurrency;
+use vln_primitives::{EscrowDetail, EscrowHandler, EscrowState};
+
+#[test]
+fn test_create_escrow_works() {
+    new_test_ext().execute_with(|| {
+        // should be able to create an escrow with available balance
+        assert_ok!(Escrow::create_escrow(
+            Origin::signed(ESCROW_CREATOR),
+            ESCROW_RECIPENT,
+            CURRENCY_ID,
+            20
+        ));
+        assert_eq!(
+            EscrowStore::<Test>::get(ESCROW_CREATOR, 1),
+            Some(EscrowDetail {
+                recipent: ESCROW_RECIPENT,
+                asset: CURRENCY_ID,
+                amount: 20,
+                state: EscrowState::Created
+            })
+        );
+        // the escrow amount should be reserved
+        assert_eq!(Tokens::free_balance(CURRENCY_ID, &ESCROW_CREATOR), 80);
+        assert_eq!(Tokens::free_balance(CURRENCY_ID, &ESCROW_RECIPENT), 0);
+
+        // should fail when escrow is more than balance
+        assert_noop!(
+            Escrow::create_escrow(
+                Origin::signed(ESCROW_CREATOR),
+                ESCROW_RECIPENT,
+                CURRENCY_ID,
+                120
+            ),
+            orml_tokens::Error::<Test>::BalanceTooLow
+        );
+        // the escrow amount should not be reserved
+        assert_eq!(Tokens::free_balance(CURRENCY_ID, &ESCROW_CREATOR), 80);
+        assert_eq!(Tokens::free_balance(CURRENCY_ID, &ESCROW_RECIPENT), 0);
+
+        // the escrow index should increment correctly
+        assert_ok!(Escrow::create_escrow(
+            Origin::signed(ESCROW_CREATOR),
+            ESCROW_RECIPENT,
+            CURRENCY_ID,
+            20
+        ));
+        assert_eq!(
+            EscrowStore::<Test>::get(ESCROW_CREATOR, 2),
+            Some(EscrowDetail {
+                recipent: ESCROW_RECIPENT,
+                asset: CURRENCY_ID,
+                amount: 20,
+                state: EscrowState::Created
+            })
+        );
+    });
+}
+
+#[test]
+fn test_release_escrow_works() {
+    new_test_ext().execute_with(|| {
+        // should be able to create an escrow with available balance
+        assert_ok!(Escrow::create_escrow(
+            Origin::signed(ESCROW_CREATOR),
+            ESCROW_RECIPENT,
+            CURRENCY_ID,
+            40
+        ));
+        assert_eq!(
+            EscrowStore::<Test>::get(ESCROW_CREATOR, 1),
+            Some(EscrowDetail {
+                recipent: ESCROW_RECIPENT,
+                asset: CURRENCY_ID,
+                amount: 40,
+                state: EscrowState::Created
+            })
+        );
+        // the escrow amount should be reserved
+        assert_eq!(Tokens::free_balance(CURRENCY_ID, &ESCROW_CREATOR), 60);
+        assert_eq!(Tokens::free_balance(CURRENCY_ID, &ESCROW_RECIPENT), 0);
+
+        // should succeed for valid swap
+        assert_ok!(Escrow::release_escrow(Origin::signed(ESCROW_CREATOR), 1));
+        // the escrow amount should be transferred
+        assert_eq!(Tokens::free_balance(CURRENCY_ID, &ESCROW_CREATOR), 60);
+        assert_eq!(Tokens::free_balance(CURRENCY_ID, &ESCROW_RECIPENT), 40);
+        assert_eq!(Tokens::total_issuance(CURRENCY_ID), 100);
+
+        // should be in released state
+        assert_eq!(
+            EscrowStore::<Test>::get(ESCROW_CREATOR, 1),
+            Some(EscrowDetail {
+                recipent: ESCROW_RECIPENT,
+                asset: CURRENCY_ID,
+                amount: 40,
+                state: EscrowState::Released
+            })
+        );
+        // cannot call release again
+        assert_noop!(
+            Escrow::release_escrow(Origin::signed(ESCROW_CREATOR), 1),
+            crate::Error::<Test>::EscrowAlreadyReleased
+        );
+    });
+}

--- a/pallets/escrow/src/tests.rs
+++ b/pallets/escrow/src/tests.rs
@@ -2,7 +2,7 @@ use crate::mock::*;
 use crate::Escrow as EscrowStore;
 use frame_support::{assert_noop, assert_ok};
 use orml_traits::MultiCurrency;
-use vln_primitives::{EscrowDetail, EscrowHandler, EscrowState};
+use vln_primitives::{EscrowDetail, EscrowState};
 
 #[test]
 fn test_create_escrow_works() {

--- a/primitives/src/escrow.rs
+++ b/primitives/src/escrow.rs
@@ -1,7 +1,7 @@
 #![allow(unused_qualifications)]
 use parity_scale_codec::{Decode, Encode};
 use scale_info::TypeInfo;
-use sp_runtime::{traits::Saturating, FixedPointNumber, FixedU128, Permill};
+use sp_runtime::DispatchError;
 
 pub type EscrowId = u32;
 
@@ -11,7 +11,7 @@ pub struct EscrowDetail<Recipent, Asset, Amount> {
     pub recipent: Recipent,
     pub asset: Asset,
     pub amount: Amount,
-    pub state: EscrowState
+    pub state: EscrowState,
 }
 
 #[derive(Encode, Decode, Debug, Clone, PartialEq, Eq, TypeInfo)]
@@ -19,5 +19,33 @@ pub struct EscrowDetail<Recipent, Asset, Amount> {
 pub enum EscrowState {
     Created,
     Released,
-    Cancelled
+    Cancelled,
+}
+
+// trait that defines how to create/release escrows for users
+pub trait EscrowHandler<Account, Asset, Amount> {
+    /// Attempt to reserve an amount of the given asset from the caller
+    /// If not possible then return Error. Possible reasons for failure include:
+    /// - User does not have enough balance.
+    fn create_escrow(
+        from: Account,
+        to: Account,
+        asset: Asset,
+        amount: Amount,
+    ) -> Result<EscrowId, DispatchError>;
+
+    /// Attempt to transfer an amount of the given asset from the given escrow_id
+    /// If not possible then return Error. Possible reasons for failure include:
+    /// - The escrow_id is not valid
+    /// - The unreserve operation fails
+    /// - The transfer operation fails
+    fn release_escrow(from: Account, escrow_id: EscrowId) -> Result<(), DispatchError>;
+
+    /// Attempt to fetch the details of an escrow from the given escrow_id
+    /// Possible reasons for failure include:
+    /// - The escrow_id is not valid
+    fn get_escrow_details(
+        from: Account,
+        escrow_id: EscrowId,
+    ) -> Option<EscrowDetail<Account, Asset, Amount>>;
 }

--- a/primitives/src/escrow.rs
+++ b/primitives/src/escrow.rs
@@ -3,12 +3,9 @@ use parity_scale_codec::{Decode, Encode};
 use scale_info::TypeInfo;
 use sp_runtime::DispatchError;
 
-pub type EscrowId = u32;
-
 #[derive(Encode, Decode, Debug, Clone, PartialEq, Eq, TypeInfo)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct EscrowDetail<Recipent, Asset, Amount> {
-    pub recipent: Recipent,
+pub struct EscrowDetail<Asset, Amount> {
     pub asset: Asset,
     pub amount: Amount,
     pub state: EscrowState,
@@ -32,20 +29,17 @@ pub trait EscrowHandler<Account, Asset, Amount> {
         to: Account,
         asset: Asset,
         amount: Amount,
-    ) -> Result<EscrowId, DispatchError>;
+    ) -> Result<(), DispatchError>;
 
     /// Attempt to transfer an amount of the given asset from the given escrow_id
     /// If not possible then return Error. Possible reasons for failure include:
     /// - The escrow_id is not valid
     /// - The unreserve operation fails
     /// - The transfer operation fails
-    fn release_escrow(from: Account, escrow_id: EscrowId) -> Result<(), DispatchError>;
+    fn release_escrow(from: Account, to: Account) -> Result<(), DispatchError>;
 
     /// Attempt to fetch the details of an escrow from the given escrow_id
     /// Possible reasons for failure include:
     /// - The escrow_id is not valid
-    fn get_escrow_details(
-        from: Account,
-        escrow_id: EscrowId,
-    ) -> Option<EscrowDetail<Account, Asset, Amount>>;
+    fn get_escrow_details(from: Account, to: Account) -> Option<EscrowDetail<Asset, Amount>>;
 }

--- a/primitives/src/escrow.rs
+++ b/primitives/src/escrow.rs
@@ -1,0 +1,23 @@
+#![allow(unused_qualifications)]
+use parity_scale_codec::{Decode, Encode};
+use scale_info::TypeInfo;
+use sp_runtime::{traits::Saturating, FixedPointNumber, FixedU128, Permill};
+
+pub type EscrowId = u32;
+
+#[derive(Encode, Decode, Debug, Clone, PartialEq, Eq, TypeInfo)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct EscrowDetail<Recipent, Asset, Amount> {
+    pub recipent: Recipent,
+    pub asset: Asset,
+    pub amount: Amount,
+    pub state: EscrowState
+}
+
+#[derive(Encode, Decode, Debug, Clone, PartialEq, Eq, TypeInfo)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum EscrowState {
+    Created,
+    Released,
+    Cancelled
+}

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -7,11 +7,11 @@
 #[macro_use]
 mod macros;
 mod asset;
-mod rates;
 mod escrow;
+mod rates;
 
 pub use asset::*;
-pub use rates::*;
 pub use escrow::*;
+pub use rates::*;
 
 pub type Share = sp_arithmetic::Permill;

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -8,8 +8,10 @@
 mod macros;
 mod asset;
 mod rates;
+mod escrow;
 
 pub use asset::*;
 pub use rates::*;
+pub use escrow::*;
 
 pub type Share = sp_arithmetic::Permill;

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -73,6 +73,7 @@ vln-backed-asset = { default-features = false, path = '../pallets/backed_asset' 
 vln-human-swap = { default-features = false, path = '../pallets/human_swap' }
 vln-transfers = { default-features = false, path = '../pallets/transfers' }
 vln-rate-provider = { default-features = false, path = '../pallets/rate_provider' }
+vln-escrow = { default-features = false, path = '../pallets/escrow' }
 
 [features]
 default = ['std']
@@ -130,5 +131,6 @@ std = [
 	'vln-rate-provider/std',
 	"cumulus-pallet-xcmp-queue/std",
 	"cumulus-pallet-xcm/std",
+	'vln-escrow/std',
 ]
 standalone = []

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -416,6 +416,11 @@ impl vln_rate_provider::Config for Runtime {
     type RateCombinator = DefaultRateCombinator;
 }
 
+impl vln_escrow::Config for Runtime {
+    type Event = Event;
+    type Asset = Tokens;
+}
+
 #[cfg(feature = "standalone")]
 pub use standalone_impl::*;
 
@@ -640,6 +645,7 @@ macro_rules! construct_vln_runtime {
                     Transfers: vln_transfers::{Call, Event<T>, Pallet, Storage},
                     Oracle: orml_oracle::{Call, Event<T>, Pallet, Storage},
                     RatesProvider: vln_rate_provider::{Call, Event<T>, Pallet, Storage},
+                    Escrow: vln_escrow::{Call, Event<T>, Pallet, Storage},
                     $($modules)*
                 }
             }


### PR DESCRIPTION
This pallet will allow users to create an escrow onchain for a selected recipent. Also implements `EscrowHandler` trait that allows other modules to utilise the escrow functions.