### PR TITLE
Ci automate release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,69 @@
+name: Create Release
+
+on:
+  push:
+    branches:
+      - automate-release
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  build:
+    # name: Build project
+    # runs-on: self-hosted
+    # steps:
+    #   - uses: actions/checkout@v2
+
+    #   - name: Cache cargo directories
+    #     uses: actions/cache@v2
+    #     with:
+    #       path: |
+    #         ~/.cargo/registry
+    #         ~/.cargo/git
+    #       key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+    #   - name: Cache cargo build
+    #     uses: actions/cache@v2
+    #     with:
+    #       path: target
+    #       key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }} 
+    #   - uses: actions-rs/toolchain@v1 
+    #     with:
+    #       toolchain: nightly-2021-02-17
+    #       target: wasm32-unknown-unknown 
+    #   - uses: actions-rs/cargo@v1
+    #     with:
+    #       command: build
+    #       args: --release -p vln-parachain
+      
+    #   - name: Build parachain artifacts
+    #     run: |
+    #       ./target/release/vln_parachain export-genesis-state --chain testnet > genesis-state
+    #       ./target/release/vln_parachain export-genesis-wasm --chain testnet > genesis-wasm
+    #       ./target/release/vln_parachain build-spec --chain testnet --disable-default-bootnode > testnet-chainspec
+      
+    #   - name: Package files
+    #     uses: actions/upload-artifact@v2
+    #     with:
+    #       name: build
+    #       if-no-files-found: error
+    #       path: |
+    #         target/release/vln_parachain
+    #         genesis-state
+    #         genesis-wasm
+    #         testnet-chainspec
+    #       retention-days: 10 #keep artifacts only for 10 days to save on storage
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          prerelease: true
+          # fail_on_unmatched_files: true
+          # files: |
+          #   target/release/vln_parachain
+          #   genesis-state
+          #   genesis-wasm
+          #   testnet-chainspec
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,10 +9,10 @@ on:
 
 jobs:
   build:
-    # name: Build project
-    # runs-on: self-hosted
-    # steps:
-    #   - uses: actions/checkout@v2
+    name: Build project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
 
     #   - name: Cache cargo directories
     #     uses: actions/cache@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Create Release
 on:
   push:
     tags:
-      - 'v*.*.*'
+      - '*'
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,60 +8,48 @@ on:
 jobs:
   build:
     name: Build project
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v2
 
-    #   - name: Cache cargo directories
-    #     uses: actions/cache@v2
-    #     with:
-    #       path: |
-    #         ~/.cargo/registry
-    #         ~/.cargo/git
-    #       key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache cargo directories
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-    #   - name: Cache cargo build
-    #     uses: actions/cache@v2
-    #     with:
-    #       path: target
-    #       key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }} 
-    #   - uses: actions-rs/toolchain@v1 
-    #     with:
-    #       toolchain: nightly-2021-02-17
-    #       target: wasm32-unknown-unknown 
-    #   - uses: actions-rs/cargo@v1
-    #     with:
-    #       command: build
-    #       args: --release -p vln-parachain
+      - name: Cache cargo build
+        uses: actions/cache@v2
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }} 
+      - uses: actions-rs/toolchain@v1 
+        with:
+          toolchain: nightly-2021-02-17
+          target: wasm32-unknown-unknown 
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release -p vln-parachain
       
-    #   - name: Build parachain artifacts
-    #     run: |
-    #       ./target/release/vln_parachain export-genesis-state --chain testnet > genesis-state
-    #       ./target/release/vln_parachain export-genesis-wasm --chain testnet > genesis-wasm
-    #       ./target/release/vln_parachain build-spec --chain testnet --disable-default-bootnode > testnet-chainspec
+      - name: Build parachain artifacts
+        run: |
+          ./target/release/vln_parachain export-genesis-state --chain testnet > genesis-state
+          ./target/release/vln_parachain export-genesis-wasm --chain testnet > genesis-wasm
+          ./target/release/vln_parachain build-spec --chain testnet --disable-default-bootnode > testnet-chainspec
       
-    #   - name: Package files
-    #     uses: actions/upload-artifact@v2
-    #     with:
-    #       name: build
-    #       if-no-files-found: error
-    #       path: |
-    #         target/release/vln_parachain
-    #         genesis-state
-    #         genesis-wasm
-    #         testnet-chainspec
-    #       retention-days: 10 #keep artifacts only for 10 days to save on storage
-
       - name: Release
         uses: softprops/action-gh-release@v1
         with:
           prerelease: true
-          # fail_on_unmatched_files: true
-          # files: |
-          #   target/release/vln_parachain
-          #   genesis-state
-          #   genesis-wasm
-          #   testnet-chainspec
+          fail_on_unmatched_files: true
+          files: |
+            target/release/vln_parachain
+            genesis-state
+            genesis-wasm
+            testnet-chainspec
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,6 @@ name: Create Release
 
 on:
   push:
-    branches:
-      - automate-release
     tags:
       - 'v*.*.*'
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,14 +1,12 @@
 name: Build and Release
 
 on:
-  push: 
-    branches:
-    - automate-release
+  pull_request:
 
 jobs:
   build:
     name: Build project
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,9 +1,9 @@
-name: Blockchain Node
+name: Build and Release
 
 on:
   push: 
     branches:
-    - master
+    - automate-release
 
 jobs:
   build:
@@ -51,4 +51,18 @@ jobs:
             genesis-wasm
             testnet-chainspec
           retention-days: 10 #keep artifacts only for 10 days to save on storage
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/') # only triggered if the head is a tag
+        prerelease: true
+        fail_on_unmatched_files: true
+        with:
+          files: |
+            target/release/vln_parachain
+            genesis-state
+            genesis-wasm
+            testnet-chainspec
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,7 +1,9 @@
-name: Build and Release
+name: Build and Pack
 
 on:
-  pull_request:
+  push:
+    branches:
+      - master
 
 jobs:
   build:
@@ -49,18 +51,4 @@ jobs:
             genesis-wasm
             testnet-chainspec
           retention-days: 10 #keep artifacts only for 10 days to save on storage
-
-      - name: Release
-        uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/') # only triggered if the head is a tag
-        with:
-          prerelease: true
-          fail_on_unmatched_files: true
-          files: |
-            target/release/vln_parachain
-            genesis-state
-            genesis-wasm
-            testnet-chainspec
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,9 +55,9 @@ jobs:
       - name: Release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/') # only triggered if the head is a tag
-        prerelease: true
-        fail_on_unmatched_files: true
         with:
+          prerelease: true
+          fail_on_unmatched_files: true
           files: |
             target/release/vln_parachain
             genesis-state

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: Build project
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
Github Action to create a new release when a new tag is pushed. [Example](https://github.com/stanly-johnson/vln-node/releases/tag/v0.0.3)
resolves #108 